### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=Libraries for the various versions of the EC sensor and different micr
 category=Sensors
 url=http://cityhydroponics.hk/
 architectures=*
-includes=
+includes=ECSensor.h
 


### PR DESCRIPTION
The includes field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > ECSensor**. Leaving this field empty causes that action to add the following line to the sketch:
```
#include <>
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format