### PR TITLE
fix ::getStatus() for all archs

### DIFF
--- a/src/ECSensor.cpp
+++ b/src/ECSensor.cpp
@@ -192,9 +192,11 @@ uint32_t ECSensor::readSensor() {
 
   uint32_t averageCycles;
   if (timeout) {
+    sensorStatus = EC_FAIL;
     averageCycles = 0;
   }
   else {
+    sensorStatus = EC_SUCCESS;
     averageCycles = (totalCycles >> oversamplingRate);
   }
   EIMSK &= ~(1 << INT0);                      // Disable INT0.
@@ -313,9 +315,11 @@ uint32_t ECSensor::readSensor() {
     delayMicroseconds(DISCHARGEDELAY);
   }
   if (timeout) {
+    sensorStatus = EC_FAIL;
     dischargeCycles = 0;
   }
   else {
+    sensorStatus = EC_SUCCESS;
     dischargeCycles = (totalCycles >> oversamplingRate);
   }   
   yield();                                    // For the ESP8266: allow for background processes to run.
@@ -360,6 +364,7 @@ void ECSensor::begin() {
 uint32_t ECSensor::readSensor() {
   uint32_t totalCycles = 0;
   bool timeout = false;
+  sensorStatus = EC_SUCCESS;
   for (uint8_t i = 0; i < (1 << oversamplingRate); i++) {
 
     ///////////////////////////////////////////////////////////////////////
@@ -399,6 +404,7 @@ uint32_t ECSensor::readSensor() {
     totalCycles += dischargeCycles;
     PCMSK &= ~(1 << INTERRUPT);               // Clear the pin change interrupt on CAPPOS.
     if (timeout) {                            // A timeout here means the sensor is not measuring anything.
+      sensorStatus = EC_FAIL;
       break;
     }
 
@@ -697,9 +703,11 @@ uint32_t ECSensor::readSensor() {
   EIMSK &= ~(1 << INT4);                      // Disable INT4
   uint32_t averageCycles;
   if (timeout) {
+    sensorStatus = EC_FAIL;
     averageCycles = 0;
   }
   else {
+    sensorStatus = EC_SUCCESS;
     averageCycles = (totalCycles >> oversamplingRate);
   }
   return averageCycles;

--- a/src/ECSensor.h
+++ b/src/ECSensor.h
@@ -60,7 +60,7 @@ class ECSensor {
 #if defined(__AVR__)
     void begin(void);
 #elif defined(ESP8266)
-    void begin(uint8_t, uint8_t, uint8_t);
+    void begin(uint8_t cp, uint8_t cn, uint8_t ec);
 #endif
     
     uint32_t readSensor(void);


### PR DESCRIPTION
- fix `::getStatus()` for all archs
- document esp8266's `::begin()`